### PR TITLE
Update gitignore to contain eclipse files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,47 @@ hs_err_pid*
 
 # macOS Files #
 *.DS_Store
+
+# eclipse files # 
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet


### PR DESCRIPTION
Update the gitginore to contain eclipse specific files / folders that do not need to be in the repo.


These have been taken from [here](https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore)