### PR TITLE
Move carbs to helper

### DIFF
--- a/src/main/java/statistics/CarbNutrition.java
+++ b/src/main/java/statistics/CarbNutrition.java
@@ -41,8 +41,7 @@ public class CarbNutrition implements NutritionType {
   
   @Override
   public void removeSubcategory(String name) {
-    total -= categoryMap.containsKey(name) ? categoryMap.get(name) : 0.0;
-    categoryMap.remove(name);
+    total -= helper.removeSubcategory(name, categoryMap);
   }
 
   @Override

--- a/src/main/java/statistics/CarbNutrition.java
+++ b/src/main/java/statistics/CarbNutrition.java
@@ -12,6 +12,7 @@ public class CarbNutrition implements NutritionType {
 
   private Double total = 0.0;
   private HashMap<String, Double> categoryMap = new HashMap<>();
+  private NutritionHelper helper = new NutritionHelper();
 
   @Override
   public Double getTotal() {
@@ -25,7 +26,6 @@ public class CarbNutrition implements NutritionType {
 
   @Override
   public void addValue(String name, Double value) {
-    NutritionHelper helper = new NutritionHelper();
     total += helper.addValue(name, categoryMap, value);
   }
 

--- a/src/main/java/statistics/CarbNutrition.java
+++ b/src/main/java/statistics/CarbNutrition.java
@@ -31,7 +31,7 @@ public class CarbNutrition implements NutritionType {
 
   @Override
   public Set<String> getSubcategoryNames() {
-    return categoryMap.keySet();
+    return helper.getSubcategoryNames(categoryMap);
   }
   
   @Override

--- a/src/main/java/statistics/CarbNutrition.java
+++ b/src/main/java/statistics/CarbNutrition.java
@@ -36,7 +36,7 @@ public class CarbNutrition implements NutritionType {
   
   @Override
   public Double getSubcategoryValue(String name) {
-    return categoryMap.get(name) == null ? 0.0 : categoryMap.get(name);
+    return helper.getValue(name, categoryMap);
   }
   
   @Override

--- a/src/main/java/statistics/CarbNutrition.java
+++ b/src/main/java/statistics/CarbNutrition.java
@@ -25,8 +25,8 @@ public class CarbNutrition implements NutritionType {
 
   @Override
   public void addValue(String name, Double value) {
-    total += value;
-    categoryMap.put(name, value);
+    NutritionHelper helper = new NutritionHelper();
+    total += helper.addValue(name, categoryMap, value);
   }
 
   @Override


### PR DESCRIPTION
Move the methods in the carb nutrition class to use the neutron helper methods,

This means that the carbs nutrition class does not have to worry about the implementation of the methods, as it has been abstracted.