### PR TITLE
Fix nutrition helper is equal

### DIFF
--- a/src/main/java/statistics/NutritionHelper.java
+++ b/src/main/java/statistics/NutritionHelper.java
@@ -102,7 +102,14 @@ public class NutritionHelper {
       return false;
     }
     
-    return (type.getValues().equals(objType.getValues()));
+    //Return false if the names are null.
+    if (type.getName() == null || objType.getName() == null) {
+      return false;
+    }
+    
+    //For two NutritionTypes to be equal, 
+    return ((type.getValues().equals(objType.getValues())) && (
+        type.getName().equals(objType.getName())));
   }
   
   /**

--- a/src/test/java/teststatistics/TestNutritionHelper.java
+++ b/src/test/java/teststatistics/TestNutritionHelper.java
@@ -325,5 +325,16 @@ public class TestNutritionHelper {
     assertTrue("Could not get different hash code for different values",
         testHelper.getHashCode(testNutrition) != testHelper.getHashCode(duplicTestNutrition));
   }  
+  
+  /**
+   * Test to try and see if two nutrition types with the same values but 
+   * different names are equal.
+   * This should be false, as the names must be equal for the NutritionTypes to be equal.
+   */
+  @Test
+  public void testEqualNutritionTypesDiffNames() {
+    assertFalse("Could not get NutritionTypes with equal names to be un-equal",
+        testHelper.getEqual(testNutrition, duplicTestNutrition));
+  }
 
 }

--- a/src/test/java/teststatistics/TestNutritionHelper.java
+++ b/src/test/java/teststatistics/TestNutritionHelper.java
@@ -334,7 +334,7 @@ public class TestNutritionHelper {
   @Test
   public void testEqualNutritionTypesDiffNames() {
     assertFalse("Could not get NutritionTypes with equal names to be un-equal",
-        testHelper.getEqual(testNutrition, duplicTestNutrition));
+        testHelper.getEqual(testNutrition, otherNutrition));
   }
 
 }


### PR DESCRIPTION
Modify the isEqual method to check to see if the names of the NutritionTypes are equal. This should only return true if the name of the type is equal as well.

This fixes #25 